### PR TITLE
(MCOP-57) add '-u USER' option to mco process list

### DIFF
--- a/agent/process.ddl
+++ b/agent/process.ddl
@@ -23,6 +23,14 @@ action "list", :description => "List Processes" do
           :type        => :boolean,
           :optional    => true
 
+    input :user,
+          :prompt      => "User's processes only",
+          :description => "Restrict the process list to processes executed as defined user",
+          :type        => :string,
+          :validation  => :shellsafe,
+          :optional    => true,
+          :maxlength    => 50
+
     output :pslist,
            :description => "Process List",
            :display_as => "The Process List"

--- a/application/process.rb
+++ b/application/process.rb
@@ -9,6 +9,11 @@ module  MCollective
              :arguments   => ['-z', '--zombies'],
              :type        => :bool
 
+      option :user,
+             :description => "Only list defined user's processes",
+             :arguments   => ['-u ARG', '--user=ARG'],
+             :type        => String
+
       option :fields,
              :description => 'Comma seperated list of outputs to display',
              :arguments   => ['--fields=FIELDS'],
@@ -72,7 +77,11 @@ module  MCollective
       def main
         PluginManager.loadclass('MCollective::Util::Process::Numeric')
         ps = rpcclient('process')
-        ps_result = ps.send(configuration[:action], :pattern => configuration[:pattern], :just_zombies => configuration[:just_zombies])
+        if configuration[:user]
+          ps_result = ps.send(configuration[:action], :pattern => configuration[:pattern], :just_zombies => configuration[:just_zombies], :user => configuration[:user])
+        else
+          ps_result = ps.send(configuration[:action], :pattern => configuration[:pattern], :just_zombies => configuration[:just_zombies])
+        end
         ps_fields = configuration[:fields]
         field_size = Array.new(ps_fields.size).fill(0) {|i| ps_fields[i].size}
         final_output = {}

--- a/spec/agent/process_agent_spec.rb
+++ b/spec/agent/process_agent_spec.rb
@@ -14,17 +14,17 @@ module MCollective
 
       describe 'list_action' do
         it 'should pass the pattern input' do
-          @agent.expects(:get_proc_list).with('rspec', false)
+          @agent.expects(:get_proc_list).with('rspec', false, false)
           @agent.call(:list, :pattern => 'rspec')
         end
 
         it 'should pass the just_zombies input' do
-          @agent.expects(:get_proc_list).with('.', true)
+          @agent.expects(:get_proc_list).with('.', true, false)
           @agent.call(:list, :just_zombies => true)
         end
 
         it 'should get the process list' do
-          @agent.expects(:get_proc_list).with('.', false).returns('rspec')
+          @agent.expects(:get_proc_list).with('.', false, false).returns('rspec')
           result = @agent.call(:list)
           result.should be_successful
           result.should have_data_items({:pslist => 'rspec'})
@@ -61,16 +61,31 @@ module MCollective
         it 'should return processes that match the supplied pattern' do
           Sys::ProcTable.stubs(:ps).returns(input)
           @agent.stubs(:ps_to_hash).with(input[0]).returns(input[0])
-          result = @agent.send(:get_proc_list, 'rspec1', false)
+          result = @agent.send(:get_proc_list, 'rspec1', false, false)
           result.should == [{'cmdline' => 'rspec1', :state => 'S'}]
         end
 
         it 'should return only zombies if just_zombies input is supplied' do
           Sys::ProcTable.stubs(:ps).returns(input)
           @agent.stubs(:ps_to_hash).with(input[1]).returns(input[1])
-          result = @agent.send(:get_proc_list, 'rspec2', true)
+          result = @agent.send(:get_proc_list, 'rspec2', true, false)
           result.should == [{'cmdline' => 'rspec2', :state => 'Z'}]
         end
+
+        it 'should return only processes executed as supplied user' do
+          Sys::ProcTable.stubs(:ps).returns(input)
+          @agent.stubs(:get_uid).with('user1').returns(500)
+          result = @agent.send(:get_proc_list, '.', false, 'user1')
+          result.should == [{'cmdline' => 'rspec1', :state => 'S', 'uid' => 500}]
+        end
+
+        it 'should return only processes executed as supplied user' do
+          Sys::ProcTable.stubs(:ps).returns(input)
+          @agent.stubs(:get_uid).with('user2').returns(502)
+          result = @agent.send(:get_proc_list, '.', false, 'user2')
+          result.should == []
+        end
+
       end
     end
   end


### PR DESCRIPTION
Sometimes i want to know if there are processes executed as specified user.
Changes allow to do it, for example:

```
[root@localhost mcollective]# mco process list -u rabbitmq

 * [ ============================================================> ] 1 / 1

   localhost.localdomain

     PID      USER         VSZ            COMMAND                                                     
     6702     rabbitmq     10.570 MB      /usr/lib64/erlang/erts-5.8.5/bin/epmd -daemon               
     7692     rabbitmq     576.332 MB     /usr/lib64/erlang/erts-5.8.5/bin/beam -W w -K true -A30 -P 1
     7766     rabbitmq     10.535 MB      inet_gethost 4                                              
     7767     rabbitmq     12.590 MB      inet_gethost 4                                              


Summary of The Process List:

           Matched hosts: 1
       Matched Processes: 4
           Resident Size: 9.893 MB
            Virtual Size: 610.027 MB


Finished processing 1 / 1 hosts in 90.63 ms
```
