### PR TITLE
Update help output in application to match renamed plugin name

### DIFF
--- a/application/process.rb
+++ b/application/process.rb
@@ -2,7 +2,7 @@ module  MCollective
   class Application
     class Process<Application
       description 'Distributed Process Management'
-      usage 'mco pgrep <pattern> [-z] [--fields=FIELDS]'
+      usage 'mco process <pattern> [-z] [--fields=FIELDS]'
 
       option :just_zombies,
              :description => 'Only list defunct processes',


### PR DESCRIPTION
Missed an instance of `pgrep`