### PR TITLE
(MCOP-606) Fix agent not returning data

### DIFF
--- a/application/process.rb
+++ b/application/process.rb
@@ -24,6 +24,7 @@ module  MCollective
              :arguments   => ['--silent'],
              :type        => :bool
 
+      require 'sys/proctable'
       def handle_message(action, message, *args)
         messages = {1 => 'Please provide an action',
                     2 => "'%s' specified as process field. Valid options are %s",


### PR DESCRIPTION
As per Michael Smith, this is not a long-term solution, but it will fix the plugin for now.

Long-term, we want to not serialize the objects, instead turning any results into simple data structures and sending those back.